### PR TITLE
Opentracing 1.6.0 compatibility

### DIFF
--- a/ci/install_opentracing.sh
+++ b/ci/install_opentracing.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-OPENTRACING_VERSION="${OPENTRACING_VERSION:-1.5.0}"
+OPENTRACING_VERSION="${OPENTRACING_VERSION:-1.6.0}"
 BUILD_DIR=/
 pushd "${BUILD_DIR}"
 git clone -b v$OPENTRACING_VERSION https://github.com/opentracing/opentracing-cpp.git

--- a/example/hello_server/jaeger/Dockerfile
+++ b/example/hello_server/jaeger/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:18.04
+FROM ubuntu:eoan
 
-ARG OPENTRACING_CPP_VERSION=v1.5.1
-ARG JAEGER_VERSION=v0.4.2
+ARG OPENTRACING_CPP_VERSION=v1.6.0
+ARG JAEGER_VERSION=47fbf19aae2e48d59dd8335b6f2a1e1a99abba7f
 
 COPY . /example
 
@@ -18,6 +18,7 @@ RUN set -x \
               ca-certificates \
               wget \
               lua5.1 lua5.1-dev \
+              libyaml-cpp-dev \
 ### Build opentracing-cpp
   && cd / \
   && git clone -b $OPENTRACING_CPP_VERSION https://github.com/opentracing/opentracing-cpp.git \
@@ -36,7 +37,16 @@ RUN set -x \
   && cd / \
   && curl -L https://github.com/luvit/lit/raw/3.6.0/get-lit.sh | sh \
 ### Install tracers
-  && wget https://github.com/jaegertracing/jaeger-client-cpp/releases/download/${JAEGER_VERSION}/libjaegertracing_plugin.linux_amd64.so -O /usr/local/lib/libjaegertracing_plugin.so \
+  && git clone https://github.com/jaegertracing/jaeger-client-cpp.git \
+  && cd /jaeger-client-cpp \
+  && git checkout ${JAEGER_VERSION} \
+  && mkdir build && cd build \
+  && cmake -DCMAKE_BUILD_TYPE=Release \
+           -DBUILD_TESTING=OFF \
+           -DJAEGERTRACING_WITH_YAML_CPP=ON .. \
+  && make && make install \
+  && ln -s /usr/local/lib/libjaegertracing.so /usr/local/lib/libjaegertracing_plugin.so \
+  && cd / \
 ### Run ldconfig
   && ldconfig
 

--- a/example/hello_server/jaeger/jaeger-config.json
+++ b/example/hello_server/jaeger/jaeger-config.json
@@ -1,6 +1,6 @@
 {
   "service_name": "lua-hello-server",
-  "diabled": false,
+  "disabled": false,
   "reporter": {
     "logSpans": true,
     "localAgentHostPort": "jaeger:6831"

--- a/src/dynamic_tracer.cpp
+++ b/src/dynamic_tracer.cpp
@@ -9,7 +9,7 @@ namespace lua_bridge_tracer {
 // DynamicSpanContext
 //--------------------------------------------------------------------------------------------------
 namespace {
-class DynamicSpanContext final : public opentracing::SpanContext {
+class DynamicSpanContext : public opentracing::SpanContext {
  public:
   DynamicSpanContext(
       std::shared_ptr<const opentracing::Tracer> tracer,
@@ -20,6 +20,10 @@ class DynamicSpanContext final : public opentracing::SpanContext {
       std::function<bool(const std::string&, const std::string&)> callback)
       const override {
     span_context_->ForeachBaggageItem(callback);
+  }
+
+  std::unique_ptr<opentracing::SpanContext> Clone() const noexcept override {
+    return span_context_->Clone();
   }
 
   const opentracing::SpanContext& context() const noexcept { 
@@ -78,6 +82,18 @@ class DynamicSpan final : public opentracing::Span {
     span_->Log(fields);
   }
 
+  void Log(opentracing::SystemTime timestamp,
+           std::initializer_list<std::pair<opentracing::string_view,
+               opentracing::Value>> fields) noexcept override {
+    span_->Log(timestamp, fields);
+  }
+
+  void Log(
+      opentracing::SystemTime timestamp,
+      const std::vector<std::pair<opentracing::string_view,
+                                  opentracing::Value>>& fields) noexcept override {
+    span_->Log(timestamp, fields);
+  }
   const opentracing::SpanContext& context() const noexcept override {
     return span_->context();
   }


### PR DESCRIPTION
Hi. It looks like v0.1.1 of lua-bridge-tracer doesn't work with [opentracing-cpp 1.6.0](https://github.com/opentracing/opentracing-cpp/releases/tag/v1.6.0).

It's been a while since I've done any C++ coding, but it looks like by just implement the 3 missing methods it compiles and works OK. I've updated and tested the hello-world example and the CI pipeline with lua 5.1, 5.2 and 5.3.

As jaeger-client-cpp still doesn't have a release with Opentracing 1.6.0 compatibility I had to compile the master branch manually in the hello-world example. This slows down the Docker container build a fair bit...